### PR TITLE
Update MassStoreCommands.h

### DIFF
--- a/libusbfatfs/include/MassStoreCommands.h
+++ b/libusbfatfs/include/MassStoreCommands.h
@@ -39,7 +39,7 @@
 	/* Includes: */
 		#include "SCSI_Codes.h"
  		#include <ps4.h>
- 		typedef unsigned char bool;
+ 		//typedef unsigned char bool; conflicting types for ‘bool’
 
 
 	/* Macros: */


### PR DESCRIPTION
fix: conflicting types for ‘bool’ typedef unsigned char bool